### PR TITLE
Added support for grouping

### DIFF
--- a/ZenCoding.Test/Grouping.cs
+++ b/ZenCoding.Test/Grouping.cs
@@ -1,34 +1,77 @@
 ﻿
-//using System;
-//using Microsoft.VisualStudio.TestTools.UnitTesting;
-//using System.Collections.Generic;
-//using System.Text;
-//using P = ZenCoding.Parser;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text;
+using P = ZenCoding.Parser;
 
-//namespace ZenCoding.Test
-//{
-//    [TestClass]
-//    public class Grouping
-//    {
-//        private ZenCoding.Parser _parser;
+namespace ZenCoding.Test
+{
+    [TestClass]
+    public class Grouping
+    {
+        private ZenCoding.Parser _parser;
 
-//        [TestInitialize]
-//        public void Initialize()
-//        {
-//            _parser = new ZenCoding.Parser();
-//        }
+        [TestInitialize]
+        public void Initialize()
+        {
+            _parser = new ZenCoding.Parser();
+        }
 
-//        [TestMethod]
-//        public void GroupingSimple()
-//        {
-//            string result = _parser.Parse("div>(header>h1)+footer", ZenType.HTML);
-//            string expected = "<div></div>" +
-//                                "<div>" +
-//                                  "<p><span></span><em></em></p>" +
-//                                  "<blockquote></blockquote>" +
-//                                "</div>";
+        [TestMethod]
+        public void SimpleGroupingExample()
+        {
+            string result = _parser.Parse("div>(header>div)+section", ZenType.HTML);
+            string expected = "<div>" +
+                                "<header>" +
+                                    "<div></div>" +
+                                "</header>" +
+                                "<section></section>" +
+                              "</div>";
 
-//            Assert.AreEqual(expected, result);
-//        }
-//    }
-//}
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+
+        }
+
+        [TestMethod]
+        public void SubGroupingExample()
+        {
+            string result = _parser.Parse("div>(header>(div>span))+section", ZenType.HTML);
+            string expected = "<div>" +
+                                "<header>" +
+                                    "<div>" +
+                                        "<span></span>" +
+                                    "</div>" +
+                                "</header>" +
+                                "<section></section>" +
+                              "</div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+
+        }
+
+        [TestMethod]
+        public void MultipleGroupingExample()
+        {
+            string result = _parser.Parse("div>(header>div)+section>(ul>li*2>a)+footer>(div>span)", ZenType.HTML);
+            string expected = "<div>" +
+                                "<header>" +
+                                    "<div></div>" +
+                                "</header>" +
+                                "<section>" +
+                                    "<ul>" +
+                                        "<li><a href=\"\"></a></li>" +
+                                        "<li><a href=\"\"></a></li>" +
+                                    "</ul>" +
+                                    "<footer>" +
+                                        "<div>" +
+                                            "<span></span>" +
+                                        "</div>" +
+                                    "</footer>" +
+                                "</section>" +
+                              "</div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+    }
+}


### PR DESCRIPTION
The implemented grouping functionality enables grouping (up to n levels of sub-grouping).
It is implemented in one single method to avoid messing with the rest of the code and reuse most of what exists.
Three tests have been added to provide evidence.
Upon running the tests I noticed no (apparent) difference in the time it takes to run them all.
Even if it's not the best way to do it, it's a start and a helping hand.
