### PR TITLE
Fixed single quotes issues, added tests, removed unused using and code cleanup

### DIFF
--- a/ZenCoding.Test/Anonymous.cs
+++ b/ZenCoding.Test/Anonymous.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
-using P = ZenCoding.Parser;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Attributes.cs
+++ b/ZenCoding.Test/Attributes.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ZenCoding.Test
 {
@@ -25,7 +21,7 @@ namespace ZenCoding.Test
 
             Assert.AreEqual(expected, result);
         }
-        
+
         [TestMethod]
         public void Attributes2()
         {
@@ -106,5 +102,14 @@ namespace ZenCoding.Test
 
             Assert.AreEqual(expected, result);
         }
-}
+
+        [TestMethod]
+        public void AttributesCrazyQuotesTest()
+        {
+            string result = _parser.Parse("p[title='Single quotes within single quotes: and this statement's ending with apostrophe'' data-foo=\"\"bar\" one\"]", ZenType.HTML);
+            string expected = "<p title=\"Single quotes within single quotes: and this statement&#39;s ending with apostrophe&#39;\" data-foo=\"&quot;bar&quot; one\"></p>";
+
+            Assert.AreEqual(expected, result);
+        }
+    }
 }

--- a/ZenCoding.Test/ClimbUp.cs
+++ b/ZenCoding.Test/ClimbUp.cs
@@ -1,9 +1,5 @@
-﻿
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
-using P = ZenCoding.Parser;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Count.cs
+++ b/ZenCoding.Test/Count.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Formatting.cs
+++ b/ZenCoding.Test/Formatting.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
-using P = ZenCoding.Parser;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Grouping.cs
+++ b/ZenCoding.Test/Grouping.cs
@@ -1,9 +1,5 @@
-﻿
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
-using P = ZenCoding.Parser;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/LoremPixel.cs
+++ b/ZenCoding.Test/LoremPixel.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 
 namespace ZenCoding.Test
 {
@@ -47,7 +46,7 @@ namespace ZenCoding.Test
         public void LoremPixel4()
         {
             string result = _parser.Parse("pix-g-999x1920-animals-SomeRandomText", ZenType.HTML);
-            
+
             string expectedStart = "http://lorempixel.com/g/999/1920/animals/";
             string expectedEnd = "/SomeRandomText/";
 
@@ -60,17 +59,18 @@ namespace ZenCoding.Test
         {
             string result = _parser.Parse("pix-20000x3599-SomeRandomText", ZenType.HTML);
             string expected = "<img src=\"http://lorempixel.com/790/1678/\" alt=\"\" />"; // the allowed bound is 0-1920
-            
+
             Assert.AreEqual(expected, result);
         }
 
         [TestMethod]
         public void LoremPixelWithAttributes()
         {
-            string result = _parser.Parse("pix[alt='tags here' title='picture title' data-foo='bar']", ZenType.HTML);
-            string expected = "<img src=\"http://lorempixel.com/g/30/30/\" alt=\"tags here\" title=\"picture title\" data-foo=\"bar\" />";
+            string result = _parser.Parse("pix[alt=\"tag's here\" title=\"picture title\" data-foo=\"bar\"]", ZenType.HTML);
+            string expected = "<img src=\"http://lorempixel.com/30/30/\" alt=\"tag&#39;s here\" title=\"picture title\" data-foo=\"bar\" />";
 
             Assert.AreEqual(expected, result);
         }
+
     }
 }

--- a/ZenCoding.Test/Parser.cs
+++ b/ZenCoding.Test/Parser.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Token.cs
+++ b/ZenCoding.Test/Token.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {

--- a/ZenCoding.Test/Validate.cs
+++ b/ZenCoding.Test/Validate.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using P = ZenCoding.HtmlParser;
 
 namespace ZenCoding.Test

--- a/ZenCoding/Html/BlockHtmlControl.cs
+++ b/ZenCoding/Html/BlockHtmlControl.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 

--- a/ZenCoding/Html/CustomHtmlInput.cs
+++ b/ZenCoding/Html/CustomHtmlInput.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web.UI;
+﻿using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
 namespace ZenCoding

--- a/ZenCoding/Html/HtmlParser.cs
+++ b/ZenCoding/Html/HtmlParser.cs
@@ -289,13 +289,17 @@ namespace ZenCoding
             if (start > -1 && end > start)
             {
                 string content = attribute.Substring(start + 1, end - start - 1);
-                List<string> parts = content.Split(' ').ToList();
-
+                List<string> parts = content.Trim().Split(' ').ToList();
+                
                 for (int i = parts.Count - 1; i > 0; i--)
                 {
                     string part = parts[i];
+                    int singleCount = part.Count(c => c == '\'');
+                    int doubleCount = part.Count(c => c == '"');
 
-                    if (part.Count(c => c == '"') == 1)
+                    if (((singleCount > 1 || doubleCount > 1) && !part.Contains("=")) || 
+                        ((doubleCount == 1) && part.EndsWith("\"")) || 
+                        ((singleCount == 1) && part.EndsWith("'")))
                     {
                         parts[i - 1] += " " + part;
                         parts.RemoveAt(i);
@@ -305,7 +309,25 @@ namespace ZenCoding
                 foreach (string part in parts)
                 {
                     string[] sides = part.Split('=');
-                    element.Attributes[sides[0]] = sides.Length == 1 ? string.Empty : sides[1].Trim('"', '\'');
+
+                    if (sides.Length == 1)
+                    {
+                        element.Attributes[sides[0]] = string.Empty;
+                    }
+                    else
+                    {
+                        sides[1] = sides[1].Trim();
+                        char firstChar = sides[1][0];
+                        char lastChar = sides[1][sides[1].Length - 1];
+                        if ((firstChar == '\'' || firstChar == '"') && firstChar == lastChar)
+                        {
+                            element.Attributes[sides[0]] = sides[1].Substring(1, sides[1].Length - 2);
+                        }
+                        else
+                        {
+                            element.Attributes[sides[0]] = sides[1];
+                        }
+                    }
                 }
             }
         }

--- a/ZenCoding/Html/SelfClosingHtmlControl.cs
+++ b/ZenCoding/Html/SelfClosingHtmlControl.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web.UI;
+﻿using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
 namespace ZenCoding

--- a/ZenCoding/Html/ValidElements.cs
+++ b/ZenCoding/Html/ValidElements.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace ZenCoding
 {


### PR DESCRIPTION
Issue #7 is resolved.

Besides the minor changes, expect zencoding to be more flexible when having double quotes, single quotes and mixture of them in attributes and values.

For an instance

```
p[title="This test has double "quotes""]
```

will output

```
<p title="This test has double &quot;quotes&quot;"></p>
```

Similarly the apostrophe S in single quoted string would be accepted and transformed to `&#39;s`.
