### PR TITLE
RegEx formatting replaced with XmlDocument to insert newline

### DIFF
--- a/ZenCoding.Test/Attributes.cs
+++ b/ZenCoding.Test/Attributes.cs
@@ -107,7 +107,7 @@ namespace ZenCoding.Test
         public void AttributesCrazyQuotesTest()
         {
             string result = _parser.Parse("p[title='Single quotes within single quotes: and this statement's ending with apostrophe'' data-foo=\"\"bar\" one\"]", ZenType.HTML);
-            string expected = "<p title=\"Single quotes within single quotes: and this statement&#39;s ending with apostrophe&#39;\" data-foo=\"&quot;bar&quot; one\"></p>";
+            string expected = "<p title=\"Single quotes within single quotes: and this statement's ending with apostrophe'\" data-foo=\"\"bar\" one\"></p>";
 
             Assert.AreEqual(expected, result);
         }

--- a/ZenCoding.Test/Formatting.cs
+++ b/ZenCoding.Test/Formatting.cs
@@ -17,11 +17,14 @@ namespace ZenCoding.Test
         [TestMethod]
         public void Formatting1()
         {
-            string result = _parser.Parse("div>a*2", ZenType.HTML);
+            string result = _parser.Parse("div>a*2+img^input", ZenType.HTML);
+
             string expected = "<div>" + Environment.NewLine +
                               "<a href=\"\"></a>" + Environment.NewLine +
                               "<a href=\"\"></a>" + Environment.NewLine +
-                              "</div>";
+                              "<img src=\"\" alt=\"\" />" + Environment.NewLine +
+                              "</div>" + Environment.NewLine +
+                              "<input type=\"\" value=\"\" />";
 
             Assert.AreEqual(expected, result);
         }

--- a/ZenCoding.Test/LoremPixel.cs
+++ b/ZenCoding.Test/LoremPixel.cs
@@ -67,7 +67,7 @@ namespace ZenCoding.Test
         public void LoremPixelWithAttributes()
         {
             string result = _parser.Parse("pix[alt=\"tag's here\" title=\"picture title\" data-foo=\"bar\"]", ZenType.HTML);
-            string expected = "<img src=\"http://lorempixel.com/30/30/\" alt=\"tag&#39;s here\" title=\"picture title\" data-foo=\"bar\" />";
+            string expected = "<img src=\"http://lorempixel.com/30/30/\" alt=\"tag's here\" title=\"picture title\" data-foo=\"bar\" />";
 
             Assert.AreEqual(expected, result);
         }

--- a/ZenCoding.Test/Shortcut/Shortcut.cs
+++ b/ZenCoding.Test/Shortcut/Shortcut.cs
@@ -47,7 +47,7 @@ namespace ZenCoding.Test
         public void ShortcutComplex()
         {
             string result = _parser.Parse("html:xt>div#header>div#logo+ul#nav>li.item-$*5>a", ZenType.HTML);
-            string expected = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" +
+            string expected = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"[]>" +
                               "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">" +
                               "<head>" +
                                   "<title></title>" +

--- a/ZenCoding/Html/HtmlElementFactory.cs
+++ b/ZenCoding/Html/HtmlElementFactory.cs
@@ -84,6 +84,7 @@ namespace ZenCoding
                 case "input":
                     CustomHtmlInput input = new CustomHtmlInput();
                     input.Attributes["value"] = "";
+                    input.Attributes["type"] = "";
                     return input;
 
                 case "img":


### PR DESCRIPTION
RegEx solution was temporary and it was failing some edge cases. With `XmlDocument`, the formatting is now more robust.
