### PR TITLE
Added support for additional implicit tag names

### DIFF
--- a/ZenCoding.Test/Html/ImplicitTags.cs
+++ b/ZenCoding.Test/Html/ImplicitTags.cs
@@ -109,5 +109,43 @@ namespace ZenCoding.Test.Html
 
             Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
         }
+
+        [TestMethod]
+        public void TableAndRow()
+        {
+            string result = _parser.Parse("table>.class-name", ZenType.HTML);
+            string expected = "<table>" +
+                              "<tr class=\"class-name\">" +
+                              "</tr>" +
+                              "</table>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void RowAndData()
+        {
+            string result = _parser.Parse("tr>.class-name", ZenType.HTML);
+            string expected = "<tr>" +
+                              "<td class=\"class-name\">" +
+                              "</td>" +
+                              "</tr>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TableAndRowAndData()
+        {
+            string result = _parser.Parse("table>.row-class-name>.data-class-name", ZenType.HTML);
+            string expected = "<table>" +
+                              "<tr class=\"row-class-name\">" +
+                              "<td class=\"data-class-name\">" +
+                              "</td>" +
+                              "</tr>" +
+                              "</table>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
     }
 }

--- a/ZenCoding/Html/HtmlParser.cs
+++ b/ZenCoding/Html/HtmlParser.cs
@@ -148,8 +148,12 @@ namespace ZenCoding
             {
                 if (i != 0 && (parts[i - 1] == "ol" || parts[i - 1] == "ul") && parts[i][0] == '>')
                     currentDefault = "li";
-                if (i != 0 && parts[i - 1] == "em" && parts[i][0] == '>')
+                else if (i != 0 && parts[i - 1] == "em" && parts[i][0] == '>')
                     currentDefault = "span";
+                else if (i != 0 && parts[i - 1] == "table" && parts[i][0] == '>')
+                    currentDefault = "tr";
+                else if (i != 0 && (parts[i - 1] == "tr" || parts[i - 1].StartsWith(">tr")) && parts[i][0] == '>')
+                    currentDefault = "td";
                 else if (currentDefault != "div" && parts[i][0] == '^')
                     currentDefault = "div";
 


### PR DESCRIPTION
Added support for `em>.class` to expand to 

```
<em><span class="class"></span></em>
```

and `table>.row>.col` to expand to 

```
<table>
    <tr class="row">
        <td class="col"></td>
    </tr>
</table>
```
