### PR TITLE
ImplicitTag: Descendant of "td" should be "div"

### DIFF
--- a/ZenCoding.Test/Html/ImplicitTags.cs
+++ b/ZenCoding.Test/Html/ImplicitTags.cs
@@ -147,5 +147,25 @@ namespace ZenCoding.Test.Html
 
             Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
         }
+
+        [TestMethod]
+        public void TableAndRowColumnsAndNestedMarkup()
+        {
+            string result = _parser.Parse("table>.a>.b>.c>.d>.e.f.g", ZenType.HTML);
+            string expected = "<table>" +
+                              "<tr class=\"a\">" +
+                              "<td class=\"b\">" +
+                              "<div class=\"c\">" +
+                              "<div class=\"d\">" +
+                              "<div class=\"e f g\">" +
+                              "</div>" +
+                              "</div>" +
+                              "</div>" +
+                              "</td>" +
+                              "</tr>" +
+                              "</table>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
     }
 }

--- a/ZenCoding/Html/HtmlParser.cs
+++ b/ZenCoding/Html/HtmlParser.cs
@@ -154,7 +154,7 @@ namespace ZenCoding
                     currentDefault = "tr";
                 else if (i != 0 && (parts[i - 1] == "tr" || parts[i - 1].StartsWith(">tr")) && parts[i][0] == '>')
                     currentDefault = "td";
-                else if (currentDefault != "div" && parts[i][0] == '^')
+                else if ((parts[i][0] == '>' && currentDefault == "td") || (currentDefault != "div" && parts[i][0] == '^'))
                     currentDefault = "div";
 
                 if (parts[i][0] == '#' || parts[i][0] == '.')


### PR DESCRIPTION
(Criteria being http://docs.emmet.io/)

Currently, the implicit tag nested inside `td` produces another `td`, which must be a `div`.

In other words, the following:

``` html
table>.a>.b>.c>.d>.e.f.g
```

must produce:

``` html
<table>
    <tr class="a">
        <td class="b">
            <div class="c">
                <div class="d">
                    <div class="e f g"></div>
                </div>
            </div>
        </td>
    </tr>
</table>
```

This PR fixes the above scenario.
