### PR TITLE
Code: Added exception for Placehold text

### DIFF
--- a/ZenCoding.Test/Html/LoremPixel.cs
+++ b/ZenCoding.Test/Html/LoremPixel.cs
@@ -14,7 +14,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixel1()
+        public void LoremPixelBasic()
         {
             string result = _parser.Parse("pix", ZenType.HTML);
             string expected = "<img src=\"http://lorempixel.com/30/30/\" alt=\"\" />";
@@ -23,7 +23,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixel2()
+        public void LoremPixelGrayScale()
         {
             string result = _parser.Parse("pix-g", ZenType.HTML);
             string expected = "<img src=\"http://lorempixel.com/g/30/30/\" alt=\"\" />";
@@ -32,7 +32,16 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixel3()
+        public void LoremPixelSingleDimension()
+        {
+            string result = _parser.Parse("pix-40", ZenType.HTML);
+            string expected = "<img src=\"http://lorempixel.com/40/40/\" alt=\"\" />";
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void LoremPixelCategory()
         {
             string result = _parser.Parse("pix-120x1879-sports-SomeRandomText", ZenType.HTML);
             string expectedStart = "http://lorempixel.com/120/1879/sports/";
@@ -43,7 +52,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixel4()
+        public void LoremPixelText()
         {
             string result = _parser.Parse("pix-g-999x1920-animals-SomeRandomText", ZenType.HTML);
 
@@ -55,7 +64,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixel5()
+        public void LoremPixelOverflowedDimensions()
         {
             string result = _parser.Parse("pix-20000x3599-SomeRandomText", ZenType.HTML);
             string expected = "<img src=\"http://lorempixel.com/790/1678/\" alt=\"\" />"; // the allowed bound is 0-1920
@@ -64,13 +73,12 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void LoremPixelWithAttributes()
+        public void LoremPixelWithAttributesWithMarkup()
         {
             string result = _parser.Parse("pix[alt=\"tag's here\" title=\"picture title\" data-foo=\"bar\"]", ZenType.HTML);
             string expected = "<img src=\"http://lorempixel.com/30/30/\" alt=\"tag's here\" title=\"picture title\" data-foo=\"bar\" />";
 
             Assert.AreEqual(expected, result);
         }
-
     }
 }

--- a/ZenCoding.Test/Html/Placehold.cs
+++ b/ZenCoding.Test/Html/Placehold.cs
@@ -14,7 +14,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void PlaceHold1()
+        public void PlaceHoldBasic()
         {
             string result = _parser.Parse("place", ZenType.HTML);
             string expected = "<img src=\"http://placehold.it/30x30/\" alt=\"\" />";
@@ -23,7 +23,7 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void PlaceHold2()
+        public void PlaceHoldFormat()
         {
             string result = _parser.Parse("place-30-png", ZenType.HTML);
             string expected = "<img src=\"http://placehold.it/30x30/png/\" alt=\"\" />";
@@ -32,26 +32,26 @@ namespace ZenCoding.Test
         }
 
         [TestMethod]
-        public void PlaceHold3()
+        public void PlaceHoldText()
         {
-            string result = _parser.Parse("place-120x1879-jpeg-t=SomeRandomText", ZenType.HTML);
-            string expected = "http://placehold.it/120x1879/jpeg/&text=SomeRandomText";
+            string result = _parser.Parse("place-120x1879-jpeg-t=Some%20Random%20Text=", ZenType.HTML);
+            string expected = "http://placehold.it/120x1879/jpeg/&text=Some%20Random%20Text="; // Text is: "Some Random Text="
 
             StringAssert.Contains(result, expected);
         }
 
         [TestMethod]
-        public void PlaceHold4()
+        public void PlaceHoldColors()
         {
-            string result = _parser.Parse("place-999x1920-EEE-FFFFFF-t=Some%20Random%20Text", ZenType.HTML);
+            string result = _parser.Parse("place-999x1920-EEE-FFFFFF-t=Some%20Random%20Text!", ZenType.HTML);
 
-            string expected = "http://placehold.it/999x1920/EEE/FFFFFF/&text=Some%20Random%20Text";
+            string expected = "http://placehold.it/999x1920/EEE/FFFFFF/&text=Some%20Random%20Text!";
 
             StringAssert.Contains(result, expected);
         }
 
         [TestMethod]
-        public void PlaceHold5()
+        public void PlaceHoldOverflowedDimensions()
         {
             string result = _parser.Parse("place-20000x3599-t=SomeRandomText", ZenType.HTML);
             string expected = "<img src=\"http://placehold.it/790x1678/&text=SomeRandomText\" alt=\"\" />"; // the allowed bound is 0-1920

--- a/ZenCoding/Commons/IParser.cs
+++ b/ZenCoding/Commons/IParser.cs
@@ -1,0 +1,7 @@
+﻿namespace ZenCoding
+{
+    interface IZenParser
+    {
+        string Parse(string zenSyntax);
+    }
+}

--- a/ZenCoding/Css/CssParser.cs
+++ b/ZenCoding/Css/CssParser.cs
@@ -2,7 +2,7 @@
 
 namespace ZenCoding
 {
-    public class CssParser
+    public class CssParser : IZenParser
     {
         public string Parse(string zenSyntax)
         {

--- a/ZenCoding/Helpers/Extensions.cs
+++ b/ZenCoding/Helpers/Extensions.cs
@@ -1,5 +1,4 @@
-﻿
-namespace ZenCoding
+﻿namespace ZenCoding
 {
     public static class Extensions
     {

--- a/ZenCoding/Html/CustomHtmlAnchor.cs
+++ b/ZenCoding/Html/CustomHtmlAnchor.cs
@@ -2,7 +2,7 @@
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
-namespace ZenCoding.Html
+namespace ZenCoding
 {
     public class CustomHtmlAnchor : HtmlAnchor
     {

--- a/ZenCoding/Html/CustomHtmlImage.cs
+++ b/ZenCoding/Html/CustomHtmlImage.cs
@@ -2,7 +2,7 @@
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
-namespace ZenCoding.Html
+namespace ZenCoding
 {
     public class CustomHtmlImage : HtmlImage
     {

--- a/ZenCoding/Html/CustomHtmlTextArea.cs
+++ b/ZenCoding/Html/CustomHtmlTextArea.cs
@@ -2,7 +2,7 @@
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
-namespace ZenCoding.Html
+namespace ZenCoding
 {
     class CustomHtmlTextArea : HtmlTextArea
     {

--- a/ZenCoding/Html/HtmlElementFactory.cs
+++ b/ZenCoding/Html/HtmlElementFactory.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
-using ZenCoding.Html;
 
 namespace ZenCoding
 {
@@ -84,6 +83,16 @@ namespace ZenCoding
             if (tagName == null)
                 return null;
 
+            HtmlControl control = TryCreateSepcialControl(tagName, type, isClone);
+
+            if (control != null)
+                return control;
+
+            return new BlockHtmlControl(tagName);
+        }
+
+        private static HtmlControl TryCreateSepcialControl(string tagName, Type type, bool isClone)
+        {
             if (tagName.StartsWith("lorem", System.StringComparison.Ordinal) ||
                 (type == typeof(LoremControl) && isClone))
             {
@@ -98,6 +107,11 @@ namespace ZenCoding
                 return new PlaceHold(tagName);
             }
 
+            return TryCreateFromStateMachine(tagName);
+        }
+
+        private static HtmlControl TryCreateFromStateMachine(string tagName)
+        {
             switch (tagName)
             {
                 case "":
@@ -267,10 +281,10 @@ namespace ZenCoding
                     return new HtmlGenericSelfClosing(tagName);
             }
 
-            return new BlockHtmlControl(tagName);
+            return null;
         }
 
-        public static Control CreateDoctypes(string part, ref List<Control> current)
+        public static Control CreateDoctypes(string part, ref IEnumerable<Control> current)
         {
             if (part == null)
                 return null;
@@ -306,7 +320,7 @@ namespace ZenCoding
                     using (HtmlControl body = HtmlElementFactory.Create("body"))
                     {
                         html.Controls.Add(body);
-                        current = new List<Control>() { body };
+                        current = new Control[] { body };
                     }
                     return root;
                 }

--- a/ZenCoding/Html/LoremPixel.cs
+++ b/ZenCoding/Html/LoremPixel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
-using ZenCoding.Html;
 
 namespace ZenCoding
 {
@@ -26,50 +25,47 @@ namespace ZenCoding
 
             parts = pixText == null ? new string[] { } : pixText.Split('-');
 
-            try
+            if (parts.Length > 1)
             {
-                if (parts.Length > 1)
+                if (parts[1].Equals("g"))
                 {
-                    if (parts[1].Equals("g"))
-                    {
-                        this.IsGray = true;
+                    this.IsGray = true;
+
+                    if (parts.Length > 2)
                         dimensions = parts[2];
+                }
+                else
+                {
+                    dimensions = parts[1];
+                }
+
+                SetDimensions(dimensions);
+
+                if (parts.Length > 2)
+                {
+                    if (this.IsGray)
+                    {
+                        category = parts[3];
+                        if (parts.Length > 4)
+                        {
+                            text = parts[4];
+                        }
                     }
                     else
                     {
-                        dimensions = parts[1];
+                        category = parts[2];
+                        if (parts.Length > 3)
+                        {
+                            text = parts[3];
+                        }
                     }
-
-                    SetDimensions(dimensions);
-
-                    if (parts.Length > 2)
+                    if (_categories.Contains(category))
                     {
-                        if (this.IsGray)
-                        {
-                            category = parts[3];
-                            if (parts.Length > 4)
-                            {
-                                text = parts[4];
-                            }
-                        }
-                        else
-                        {
-                            category = parts[2];
-                            if (parts.Length > 3)
-                            {
-                                text = parts[3];
-                            }
-                        }
-                        if (_categories.Contains(category))
-                        {
-                            this.Category = category;
-                            this.Text = text;
-                        }
+                        this.Category = category;
+                        this.Text = text;
                     }
                 }
             }
-            catch
-            { }
 
             this.AssetWidth = this.AssetWidth % 1921;
             this.AssetHeight = this.AssetHeight % 1921;

--- a/ZenCoding/Html/PixelBase.cs
+++ b/ZenCoding/Html/PixelBase.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 
-namespace ZenCoding.Html
+namespace ZenCoding
 {
     public abstract class PixelBase : CustomHtmlImage
     {
@@ -11,7 +11,7 @@ namespace ZenCoding.Html
         public int AssetWidth { get; set; }
         public int AssetHeight { get; set; }
 
-        public PixelBase()
+        protected PixelBase()
         {
             Initialize();
         }
@@ -22,6 +22,9 @@ namespace ZenCoding.Html
 
         protected void SetDimensions(string slug)
         {
+            if (string.IsNullOrEmpty(slug))
+                return;
+
             var dimensions = _numberExtractor.Split(slug);
 
             if (ValidateIntegers(dimensions))
@@ -43,7 +46,7 @@ namespace ZenCoding.Html
                 {
                     Convert.ToInt32(value, CultureInfo.CurrentCulture);
                 }
-                catch
+                catch (AggregateException)
                 {
                     return false;
                 }

--- a/ZenCoding/Html/Placehold.cs
+++ b/ZenCoding/Html/Placehold.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
-using ZenCoding.Html;
 
 namespace ZenCoding
 {
@@ -34,33 +33,30 @@ namespace ZenCoding
             string dimensions = "";
             string[] parts;
 
-            parts = pixText == null ? new string[] { } : pixText.Split('-');
+            parts = pixText == null ? new string[] { } : pixText.Trim('-').Split('-');
 
-            try
+            if (parts.Length > 1)
             {
-                if (parts.Length > 1)
+                dimensions = parts[1];
+
+                SetDimensions(dimensions);
+
+                if (parts.Length > 2)
                 {
-                    dimensions = parts[1];
+                    if (_formats.Contains(parts[2]))
+                        this.Format = parts[2];
+                    else
+                        SetTextAndColors(parts[2]);
 
-                    SetDimensions(dimensions);
-
-                    if (parts.Length > 2)
-                    {
-                        if (_formats.Contains(parts[2]))
-                            this.Format = parts[2];
-                        else
-                            SetTextAndColors(parts[2]);
-
-                        if (parts.Length > 3)
-                            SetTextAndColors(parts[3]);
-
-                        if (parts.Length > 4)
-                            SetTextAndColors(parts[4]);
-                    }
+                    if (parts.Length > 3)
+                        SetTextAndColors(parts[3]);
+                    if (parts.Length > 4)
+                        SetTextAndColors(parts[4]);
                 }
             }
-            catch
-            { }
+
+            if (pixText.Last() == '-')
+                this.Text += '-';
 
             this.AssetWidth = this.AssetWidth % 1921;
             this.AssetHeight = this.AssetHeight % 1921;
@@ -71,7 +67,7 @@ namespace ZenCoding
         private void SetTextAndColors(string slug)
         {
             if (string.IsNullOrEmpty(this.Text) && slug.Contains("="))
-                this.Text = slug.Split('=')[1];
+                this.Text = string.Join("=", slug.Split('=').Skip(1));
             else if ((slug.Length == 3 || slug.Length == 6) && slug.All(c => c.IsHex()))
                 if (string.IsNullOrEmpty(this.Background))
                     this.Background = slug;

--- a/ZenCoding/Parser.cs
+++ b/ZenCoding/Parser.cs
@@ -1,8 +1,9 @@
-﻿
-namespace ZenCoding
+﻿namespace ZenCoding
 {
     public class Parser
     {
+        IZenParser _parser;
+
         public string Parse(string zenSyntax, ZenType type)
         {
             if (zenSyntax == null)
@@ -11,12 +12,11 @@ namespace ZenCoding
             switch (type)
             {
                 case ZenType.HTML:
-                    HtmlParser htmlParser = new HtmlParser();
-                    return htmlParser.Parse(zenSyntax.Trim());
-
+                    this._parser = new HtmlParser();
+                    return this._parser.Parse(zenSyntax.Trim());
                 case ZenType.CSS:
-                    CssParser cssParser = new CssParser();
-                    return cssParser.Parse(zenSyntax.Trim());
+                    this._parser = new CssParser();
+                    return this._parser.Parse(zenSyntax.Trim());
             }
 
             return null;

--- a/ZenCoding/ZenCoding.csproj
+++ b/ZenCoding/ZenCoding.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Css\CssParser.cs" />
+    <Compile Include="Commons\IParser.cs" />
     <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Html\BlockHtmlControl.cs" />
     <Compile Include="Html\CustomHtmlMeta.cs" />


### PR DESCRIPTION
- Added exception for Placehold text (now the &text=string can end with `=`, `!` and `-`).
- Several Code Analysis fixes.
