### PR TITLE
Lorem: Rendering issue fixed. (#37)

### DIFF
--- a/ZenCoding.Test/Html/Formatting.cs
+++ b/ZenCoding.Test/Html/Formatting.cs
@@ -79,5 +79,31 @@ namespace ZenCoding.Test
             Assert.AreEqual(expected, result);
         }
 
+        [TestMethod]
+        public void Formatting7()
+        {
+            string result = _parser.Parse("ul>li*3>{some text}", ZenType.HTML);
+            string expected = "<ul>" +
+                    Environment.NewLine + "<li>some text</li>" +
+                    Environment.NewLine + "<li>some text</li>" +
+                    Environment.NewLine + "<li>some text</li>" +
+                    Environment.NewLine + "</ul>";
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Formatting8()
+        {
+            string result = _parser.Parse("ul>li*3>lorem", ZenType.HTML);
+            string expected = "<ul>" +
+                    Environment.NewLine + "<li>random lorem text</li>" +
+                    Environment.NewLine + "<li>random lorem text</li>" +
+                    Environment.NewLine + "<li>random lorem text</li>" +
+                    Environment.NewLine + "</ul>";
+
+            Assert.AreEqual(expected.Split(Environment.NewLine.ToCharArray()).Length, result.Split(Environment.NewLine.ToCharArray()).Length);
+        }
+
     }
 }

--- a/ZenCoding.Test/Html/Lorem.cs
+++ b/ZenCoding.Test/Html/Lorem.cs
@@ -18,9 +18,8 @@ namespace ZenCoding.Test
         public void Lorem1()
         {
             string result = _parser.Parse("lorem", ZenType.HTML);
-            string expected = "Lorem ipsum dolor sit amet, consectetur adipiscing elit fusce vel sapien elit in malesuada semper mi, id sollicitudin urna fermentum ut fusce varius nisl ac ipsum gravida vel pretium tellus.";
 
-            Assert.AreEqual(expected, result);
+            Assert.AreEqual(result.Split().Length, 30);
         }
 
         [TestMethod]
@@ -28,25 +27,31 @@ namespace ZenCoding.Test
         {
             string result = _parser.Parse("lorem*3", ZenType.HTML);
 
-            Assert.AreEqual(result.Split(new string[] { Environment.NewLine }, StringSplitOptions.None).Length, 3);
+            Assert.AreEqual(result.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length, 3);
         }
 
         [TestMethod]
         public void Lorem3()
         {
             string result = _parser.Parse("p>lorem", ZenType.HTML);
-            string expected = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit fusce vel sapien elit in malesuada semper mi, id sollicitudin urna fermentum ut fusce varius nisl ac ipsum gravida vel pretium tellus.</p>";
 
-            Assert.AreEqual(expected, result.Replace(Environment.NewLine, ""));
+            Assert.AreEqual(result.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length, 1);
         }
 
         [TestMethod]
         public void LoremCount()
         {
             string result = _parser.Parse("p>lorem10", ZenType.HTML);
-            string expected = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit fusce vel.</p>";
 
-            Assert.AreEqual(expected, result.Replace(Environment.NewLine, ""));
+            Assert.AreEqual(result.Split().Length, 10);
+        }
+
+        [TestMethod]
+        public void LoremWithText()
+        {
+            string result = _parser.Parse("div>lorem+{some text}", ZenType.HTML);
+
+            Assert.AreEqual(result.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length, 4);
         }
 
         [TestMethod]

--- a/ZenCoding/Html/EmptyHtmlControl.cs
+++ b/ZenCoding/Html/EmptyHtmlControl.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.UI;
+﻿using System;
+using System.Web.UI;
 using System.Web.UI.HtmlControls;
 
 namespace ZenCoding
@@ -12,7 +13,22 @@ namespace ZenCoding
 
         protected override void Render(HtmlTextWriter writer)
         {
+            if (writer == null)
+                return;
+
             base.RenderChildren(writer);
+
+            var count = this.Parent.Controls.Count;
+
+            if (count < 2)
+                return;
+
+            var index = this.Parent.Controls.IndexOf(this);
+
+            if ((index == 0 && this.Parent.Controls[index + 1] is EmptyHtmlControl) || index > 0 &&
+                ((index == --count && this.Parent.Controls[count] is EmptyHtmlControl) ||
+                (this.Parent.Controls[index - 1] is EmptyHtmlControl || this.Parent.Controls[index + 1] is EmptyHtmlControl)))
+                writer.WriteLine(Environment.NewLine);
         }
     }
 }

--- a/ZenCoding/Html/HtmlElementFactory.cs
+++ b/ZenCoding/Html/HtmlElementFactory.cs
@@ -36,17 +36,18 @@ namespace ZenCoding
                     control.ID = element.ID.Increment(count);
                 }
 
-                if (element.Controls.Count == 1)
-                {
-                    LiteralControl literal = element.Controls[0] as LiteralControl;
-                    if (literal != null)
-                        control.Controls.Add(new LiteralControl(literal.Text.Increment(count)));
-                }
-
                 var lorem = element as LoremControl;
+
                 if (lorem != null)
                 {
-                    lorem.InnerText = lorem.Generate(count);
+                    (control as LoremControl).InnerText = lorem.Generate(count);
+                }
+                else if (element.Controls.Count == 1)
+                {
+                    LiteralControl literal = element.Controls[0] as LiteralControl;
+
+                    if (literal != null)
+                        control.Controls.Add(new LiteralControl(literal.Text.Increment(count)));
                 }
 
                 return control;

--- a/ZenCoding/Html/LoremControl.cs
+++ b/ZenCoding/Html/LoremControl.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Web.UI;
 
 namespace ZenCoding
 {
@@ -61,15 +60,6 @@ namespace ZenCoding
             }
 
             return result;
-        }
-
-        protected override void Render(HtmlTextWriter writer)
-        {
-            if (writer == null)
-                return;
-
-            base.RenderChildren(writer);
-            writer.Write(Environment.NewLine);
         }
     }
 }


### PR DESCRIPTION
Fixes #37.

Now the text nodes would behave the same way as the other inline controls.

For instance:

``` html
div>lorem+{more custom text}
```

would expand as:

``` html
<div>
    Tincidunt integer eu augue augue nunc elit dolor, luctus placerat scelerisque euismod, iaculis eu lacus nunc mi elit, vehicula ut laoreet ac, aliquam sit amet justo nunc tempor, metus vel.
    more custom text
</div>
```

Similarly, multiple lorem controls would get the linebreak:

``` html
div>lorem+lorem+lorem
```

would expand as:

``` html
<div>
    Tincidunt integer eu augue augue nunc elit dolor, luctus placerat scelerisque euismod, iaculis eu lacus nunc mi elit, vehicula ut laoreet ac, aliquam sit amet justo nunc tempor, metus vel.
    Placerat suscipit, orci nisl iaculis eros, a tincidunt nisi odio eget lorem nulla condimentum tempor mattis ut vitae feugiat augue cras ut metus a risus iaculis scelerisque eu ac ante.
    Fusce non varius purus aenean nec magna felis fusce vestibulum velit mollis odio sollicitudin lacinia aliquam posuere, sapien elementum lobortis tincidunt, turpis dui ornare nisl, sollicitudin interdum turpis nunc eget.
</div>
```

This is different from saying `div>lorem*3`; in which case we get same string three times (generate once, then multiply stamping).

For single nodes, it won't expand:

`p>lorem`, would render

``` html
<p>Tincidunt integer eu augue augue nunc elit dolor, luctus placerat scelerisque euismod, iaculis eu lacus nunc mi elit, vehicula ut laoreet ac, aliquam sit amet justo nunc tempor, metus vel.</p>
```
