### PR TITLE
Support custom elements, like Angular directives or Ionic tags

### DIFF
--- a/ZenCoding.Test/Html/Attributes.cs
+++ b/ZenCoding.Test/Html/Attributes.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace ZenCoding.Test
 {
@@ -101,6 +102,14 @@ namespace ZenCoding.Test
             string expected = "<input type=\"button\" value=\"\" />";
 
             Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void CustomElement()
+        {
+            string result = _parser.Parse("!ion-ico", ZenType.HTML);
+            Assert.AreEqual("<ion-ico></ion-ico>", result.Replace(Environment.NewLine, string.Empty));
+
         }
 
         [TestMethod]

--- a/ZenCoding.Test/Html/Validate.cs
+++ b/ZenCoding.Test/Html/Validate.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using ZenParser = ZenCoding.HtmlParser;
 
 namespace ZenCoding.Test
@@ -31,6 +31,7 @@ namespace ZenCoding.Test
             Assert.IsFalse(ZenParser.IsValid("div[text]]>div"));
             Assert.IsFalse(ZenParser.IsValid("asp:literal"));
             Assert.IsFalse(ZenParser.IsValid("ASP:LITERAL"));
+            Assert.IsTrue(ZenParser.IsValid("!ion-list"));
         }
 
         [TestMethod]

--- a/ZenCoding/Html/BlockHtmlControl.cs
+++ b/ZenCoding/Html/BlockHtmlControl.cs
@@ -8,7 +8,7 @@ namespace ZenCoding
     {
         public BlockHtmlControl(string tagName)
         {
-            TagName = tagName;
+            TagName = tagName.Replace("!", "");
         }
 
         protected override void RenderBeginTag(HtmlTextWriter writer)

--- a/ZenCoding/Html/HtmlParser.cs
+++ b/ZenCoding/Html/HtmlParser.cs
@@ -192,7 +192,8 @@ namespace ZenCoding
                     !firstElement.StartsWith("lorem", StringComparison.Ordinal) &&
                     !firstElement.StartsWith("pix", StringComparison.Ordinal) &&
                     !firstElement.StartsWith("place", StringComparison.Ordinal) &&
-                    firstElement != "h$")
+                    firstElement != "h$"
+                    && !firstElement.StartsWith("!", StringComparison.Ordinal))
 
                     return false;
             }


### PR DESCRIPTION
Support custom elements, like Angular directives or Ionic tags.

I use a wildcard "!" to add this custom tags, i.e.,

```
!ion-items>!ion-item
```
transforms into:
```
<ion-items>
  <ion-item>
  </ion-item>
</ion-items>
```