### PR TITLE
Added some tests to disprove some github user issues. Remove two.

### DIFF
--- a/ZenCoding.Test/Html/Parser.cs
+++ b/ZenCoding.Test/Html/Parser.cs
@@ -103,5 +103,89 @@ namespace ZenCoding.Test
 
             Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
         }
+
+
+        [TestMethod]
+        public void TestExtendAllTags_1()
+        {
+            string result = _parser.Parse("p>input", ZenType.HTML);
+            string expected = "<p>" +
+                              "<input type=\"\" value=\"\" />" +
+                              "</p>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExtendAllTags_2()
+        {
+            string result = _parser.Parse("tr>th", ZenType.HTML);
+            string expected = "<tr>" +
+                              "<th></th>" +
+                              "</tr>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExtendAllAttributes_1()
+        {
+            string result = _parser.Parse("div.ui.content", ZenType.HTML);
+            string expected = "<div class=\"ui content\"></div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExtendAllAttributes_2()
+        {
+            string result = _parser.Parse(".ui.primary.button", ZenType.HTML);
+            string expected = "<div class=\"ui primary button\"></div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExtendAllAttributes_3()
+        {
+            string result = _parser.Parse("#foo>span", ZenType.HTML);
+            string expected = "<div id=\"foo\">" +
+                              "<span></span>" +
+                              "</div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExoticExpansion_1()
+        {
+            string result = _parser.Parse("(#main^#header^#div^#map)", ZenType.HTML);
+            string expected = "<div id=\"main\"></div>" +
+                              "<div id=\"header\"></div>" +
+                              "<div id=\"div\"></div>" +
+                              "<div id=\"map\"></div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
+        [TestMethod]
+        public void TestExoticExpansion_2()
+        {
+            string result = _parser.Parse("(#header>ul#menu>li*6>a)+#main", ZenType.HTML);
+            string expected = "<div id=\"header\">" +
+                              "<ul id=\"menu\">" +
+                              "<li><a href=\"\"></a></li>" +
+                              "<li><a href=\"\"></a></li>" +
+                              "<li><a href=\"\"></a></li>" +
+                              "<li><a href=\"\"></a></li>" +
+                              "<li><a href=\"\"></a></li>" +
+                              "<li><a href=\"\"></a></li>" +
+                              "</ul>" +
+                              "</div>" +
+                              "<div id=\"main\"></div>";
+
+            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
+        }
+
     }
 }

--- a/ZenCoding.Test/Html/Validate.cs
+++ b/ZenCoding.Test/Html/Validate.cs
@@ -41,23 +41,5 @@ namespace ZenCoding.Test
 
             Assert.AreEqual(string.Empty, result);
         }
-
-        [TestMethod]
-        public void ValidateHtmlElements()
-        {
-            string result = _parser.Parse("for", ZenType.HTML);
-            string expected = "";
-
-            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
-        }
-
-        [TestMethod]
-        public void ValidateMultipleHtmlElements()
-        {
-            string result = _parser.Parse("div>for", ZenType.HTML);
-            string expected = "";
-
-            Assert.AreEqual(expected, result.Replace(Environment.NewLine, string.Empty));
-        }
     }
 }


### PR DESCRIPTION
Hi Mads Kristensen,
In this request I removed two tests which I don't think are valid anymore as of HTML5. 'for' Could be a valid tag in HTML5. If you don't agree, please revert my last change.
Also, I added some tests to disprove some issues from https://github.com/madskristensen/ZenCodingVS/issues . Specifically issues 2, 9 and 10. I did find the answer in issue 3 very interesting and I did wanted to make sure this one does not break; I made a test for it.
Thanks in advance!
Ps. You could update the ZenCodingVS extension :)